### PR TITLE
Usar Mi para la memoria en vez de Gi

### DIFF
--- a/values/production/pyarweb.yaml
+++ b/values/production/pyarweb.yaml
@@ -19,7 +19,7 @@ service:
 resources:
   limits:
     cpu: 512m
-    memory: 512Gi
+    memory: 512Mi
   requests:
     cpu: 200m
     memory: 256Mi

--- a/values/staging/pyarweb.yaml
+++ b/values/staging/pyarweb.yaml
@@ -19,7 +19,7 @@ service:
 resources:
   limits:
     cpu: 512m
-    memory: 512Gi
+    memory: 512Mi
   requests:
     cpu: 200m
     memory: 256Mi


### PR DESCRIPTION
La Web de Pyar la configure para 512G de ram en vez de MB de ram