### PR TITLE
Added some new redirects.

### DIFF
--- a/redirects/diversidad.yaml
+++ b/redirects/diversidad.yaml
@@ -1,0 +1,22 @@
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: redirect-diversidad
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/permanent-redirect: https://ac.python.org.ar/diversidad/index.html
+spec:
+  tls:
+    - hosts:
+        - diversidad.python.org.ar
+        - diversidad.python.ar
+        - diversidad.python.com.ar
+        - diversidad.pyar.org.ar
+      secretName: diversidad-tls-secret
+  rules:
+    - host: diversidad.python.org.ar
+    - host: diversidad.python.ar
+    - host: diversidad.python.com.ar
+    - host: diversidad.pyar.org.ar

--- a/redirects/foro.yaml
+++ b/redirects/foro.yaml
@@ -1,0 +1,30 @@
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: redirect-foro
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/permanent-redirect: https://pyar.discourse.group/
+spec:
+  tls:
+    - hosts:
+        - charlas.python.org.ar
+        - charlas.python.ar
+        - charlas.python.com.ar
+        - charlas.pyar.org.ar
+        - listas.python.org.ar
+        - listas.python.ar
+        - listas.python.com.ar
+        - listas.pyar.org.ar
+      secretName: foro-tls-secret
+  rules:
+    - host: charlas.python.org.ar
+    - host: charlas.python.ar
+    - host: charlas.python.com.ar
+    - host: charlas.pyar.org.ar
+    - host: listas.python.org.ar
+    - host: listas.python.ar
+    - host: listas.python.com.ar
+    - host: listas.pyar.org.ar

--- a/redirects/planeta.yaml
+++ b/redirects/planeta.yaml
@@ -1,0 +1,22 @@
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: redirect-planeta
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/permanent-redirect: https://planeta.python.org.ar/
+spec:
+  tls:
+    - hosts:
+        - planet.python.org.ar
+        - planet.python.ar
+        - planet.python.com.ar
+        - planet.pyar.org.ar
+      secretName: planeta-tls-secret
+  rules:
+    - host: planet.python.org.ar
+    - host: planet.python.ar
+    - host: planet.python.com.ar
+    - host: planet.pyar.org.ar

--- a/redirects/pyconar.yaml
+++ b/redirects/pyconar.yaml
@@ -1,0 +1,30 @@
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: redirect-pyconar
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/temporal-redirect: https://eventos.python.org.ar/events/pyconar2021/
+spec:
+  tls:
+    - hosts:
+        - ar.pycon.org
+        - pycon.com.ar
+        - www.pycon.com.ar
+        - pycon.ar
+        - pyconar.python.org.ar
+        - pyconar.python.ar
+        - pyconar.python.com.ar
+        - pyconar.pyar.org.ar
+      secretName: pyconar-tls-secret
+  rules:
+    - host: ar.pycon.org
+    - host: pycon.com.ar
+    - host: www.pycon.com.ar
+    - host: pycon.ar
+    - host: pyconar.python.org.ar
+    - host: pyconar.python.ar
+    - host: pyconar.python.com.ar
+    - host: pyconar.pyar.org.ar

--- a/stable/pyar-rewrites/templates/config_map.yaml
+++ b/stable/pyar-rewrites/templates/config_map.yaml
@@ -28,39 +28,11 @@ data:
           }
       }
 
-      # PyCon Argentina
-      server {  
-        listen 80; 
-        server_name ar.pycon.org www.pycon.com.ar pycon.com.ar pyconar.python.org.ar pycon.ar;
-        return 301 https://eventos.python.org.ar/events/pyconar2021/; 
-      } 
-
       # Main site
       server {
         listen 80;
         server_name web.python.org.ar python.org.ar;
         return 301 https://www.python.org.ar$request_uri;
-      }
-
-      # Planeta
-      server {
-        listen 80;
-        server_name planet.python.org.ar;
-        return 301 http://planeta.python.org.ar/;
-      }
-
-      # Diversidad
-      server {
-        listen 80;
-        server_name diversidad.python.org.ar;
-        return 301 https://ac.python.org.ar/diversidad/index.html;
-      }
-
-      # Foro Discourse
-      server {
-        listen 80;
-        server_name charlas.python.org.ar listas.python.org.ar;
-        return 301 https://pyar.discourse.group/;
       }
 
     }


### PR DESCRIPTION
Still not in use.

FTR, this is the YAML we built when testing how everything could work in the meeting a couple of weeks ago:

```
kind: Ingress
apiVersion: extensions/v1beta1
metadata:
  name: redirect-prueba
  annotations:
    kubernetes.io/ingress.class: nginx
    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
    nginx.ingress.kubernetes.io/ssl-redirect: "true"
    nginx.ingress.kubernetes.io/permanent-redirect: https://taniquetil.com.ar
    nginx.ingress.kubernetes.io/configuration-snippet: |
         rewrite /wiki/(.*) $scheme://wiki.python.org.ar/$1 permanent;
         rewrite ^ https://www.python.org.ar$request_uri permanent;
spec:
  tls:
    - hosts:
        - redirect-loco.python.org.ar
        - redirect-loco.python.ar
      secretName: redirectloco-tls-secret
  rules:
    - host: redirect-loco.python.org.ar
    - host: redirect-loco.python.ar
```